### PR TITLE
Include metadata fields in schema

### DIFF
--- a/src/main/dumpers/schemas/metadatalist.h
+++ b/src/main/dumpers/schemas/metadatalist.h
@@ -1,0 +1,98 @@
+/**
+ * =============================================================================
+ * DumpSource2
+ * Copyright (C) 2024 ValveResourceFormat Contributors
+ * 
+ * Source2Gen
+ * Copyright (C) 2024 neverlosecc
+ * =============================================================================
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License, version 3.0, as published by the
+ * Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+#pragma once
+#include <array>
+#include "utils/hash.h"
+
+// List of printable metadata entries that are not tied to any structures.
+// These are used to determine if we can include the corresponding metadata entry value in the dump.
+// Original list sourced from Source2Gen project.
+
+constinit std::array string_metadata_entries = {
+	FNV32("MCellForDomain"),
+	FNV32("MCustomFGDMetadata"),
+	FNV32("MFieldVerificationName"),
+	FNV32("MKV3TransferName"),
+	FNV32("MNetworkAlias"),
+	FNV32("MNetworkChangeCallback"),
+	FNV32("MNetworkEncoder"),
+	FNV32("MNetworkExcludeByName"),
+	FNV32("MNetworkExcludeByUserGroup"),
+	FNV32("MNetworkIncludeByName"),
+	FNV32("MNetworkIncludeByUserGroup"),
+	FNV32("MNetworkReplayCompatField"),
+	FNV32("MNetworkSerializer"),
+	FNV32("MNetworkTypeAlias"),
+	FNV32("MNetworkUserGroup"),
+	FNV32("MNetworkUserGroupProxy"),
+	FNV32("MParticleReplacementOp"),
+	FNV32("MPropertyArrayElementNameKey"),
+	FNV32("MPropertyAttributeChoiceName"),
+	FNV32("MPropertyAttributeEditor"),
+	FNV32("MPropertyAttributeRange"),
+	FNV32("MPropertyAttributeSuggestionName"),
+	FNV32("MPropertyCustomEditor"),
+	FNV32("MPropertyCustomFGDType"),
+	FNV32("MPropertyDescription"),
+	FNV32("MPropertyExtendedEditor"),
+	FNV32("MPropertyFriendlyName"),
+	FNV32("MPropertyFriendlyName"),
+	FNV32("MPropertyGroupName"),
+	FNV32("MPropertyIconName"),
+	FNV32("MPropertyStartGroup"),
+	FNV32("MPropertySuppressExpr"),
+	FNV32("MPulseEditorHeaderIcon"),
+	FNV32("MResourceBlockType"),
+	FNV32("MScriptDescription"),
+	FNV32("MSrc1ImportAttributeName"),
+	FNV32("MSrc1ImportDmElementType"),
+	FNV32("MVDataOutlinerIcon"),
+	FNV32("MVDataOutlinerIconExpr"),
+	FNV32("MVDataUniqueMonotonicInt"),
+	FNV32("MVectorIsSometimesCoordinate"),
+};
+
+constinit std::array inline_string_metadata_entries = {
+	FNV32("MResourceTypeForInfoType"),
+	FNV32("MDiskDataForResourceType"),
+};
+
+constinit std::array integer_metadata_entries = {
+	FNV32("MNetworkVarEmbeddedFieldOffsetDelta"),
+	FNV32("MNetworkBitCount"),
+	FNV32("MNetworkPriority"),
+	FNV32("MParticleOperatorType"),
+	FNV32("MPropertySortPriority"),
+	FNV32("MParticleMinVersion"),
+	FNV32("MParticleMaxVersion"),
+	FNV32("MNetworkEncodeFlags"),
+	FNV32("MResourceVersion"),
+	FNV32("MVDataNodeType"),
+	FNV32("MVDataOverlayType"),
+	FNV32("MAlignment"),
+	FNV32("MGenerateArrayKeynamesFirstIndex"),
+};
+
+constinit std::array float_metadata_entries = {
+	FNV32("MNetworkMinValue"),
+	FNV32("MNetworkMaxValue"),
+};

--- a/src/main/dumpers/schemas/schemas.cpp
+++ b/src/main/dumpers/schemas/schemas.cpp
@@ -27,6 +27,9 @@
 #include <unordered_set>
 #include <algorithm>
 #include "metadatalist.h"
+#include <optional>
+#include <cstring>
+#include <fmt/format.h>
 
 namespace Dumpers::Schemas
 {
@@ -35,7 +38,7 @@ std::optional<std::string> GetMetadataValue(const SchemaMetadataEntryData_t& ent
 {
 	const auto hashedName = hash_32_fnv1a_const(entry.m_pszName);
 	if (std::ranges::find(string_metadata_entries, hashedName) != string_metadata_entries.end()) {
-		return std::format("\"{}\"", *static_cast<const char**>(entry.m_pData));
+		return fmt::format("\"{}\"", *static_cast<const char**>(entry.m_pData));
 	}
 	else if (std::ranges::find(integer_metadata_entries, hashedName) != integer_metadata_entries.end()) {
 		int result;
@@ -52,10 +55,10 @@ std::optional<std::string> GetMetadataValue(const SchemaMetadataEntryData_t& ent
 		char* result = static_cast<char*>(entry.m_pData);
 		for (uint8_t i = 0; i < 8; ++i) {
 			if (result[i] == '\0') {
-				return std::format("\"{}\"", std::string(result, i));
+				return fmt::format("\"{}\"", std::string(result, i));
 			}
 		}
-		return std::format("\"{}\"", std::string(result, 8));
+		return fmt::format("\"{}\"", std::string(result, 8));
 	}
 	return {};
 }
@@ -65,9 +68,8 @@ void OutputMetadataEntry(const SchemaMetadataEntryData_t& entry, std::ofstream& 
 	output << (tabulate ? "\t" : "") << "// " << entry.m_pszName;
 	const auto metadataValue = GetMetadataValue(entry);
 	if (metadataValue)
-	{
 		output << " = " << *metadataValue;
-	}
+
 	output << "\n";
 }
 

--- a/src/main/utils/hash.h
+++ b/src/main/utils/hash.h
@@ -1,0 +1,36 @@
+/**
+ * =============================================================================
+ * DumpSource2
+ * Copyright (C) 2024 ValveResourceFormat Contributors
+ * =============================================================================
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License, version 3.0, as published by the
+ * Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+#include <cstdint>
+// FNV1a c++11 constexpr compile time hash functions, 32 and 64 bit
+// str should be a null terminated string literal, value should be left out 
+// e.g hash_32_fnv1a_const("example")
+// code license: public domain or equivalent
+// post: https://notes.underscorediscovery.com/constexpr-fnv1a/
+
+constexpr uint32_t val_32_const = 0x811c9dc5;
+constexpr uint32_t prime_32_const = 0x1000193;
+
+inline constexpr uint32_t hash_32_fnv1a_const(const char* const str, const uint32_t value = val_32_const) noexcept {
+	return (str[0] == '\0') ? value : hash_32_fnv1a_const(&str[1], (value ^ uint32_t((uint8_t)str[0])) * prime_32_const);
+}
+
+// Short name to be less verbose
+#define FNV32(str) hash_32_fnv1a_const(str)


### PR DESCRIPTION
This change includes metadata names and values in dumps for classes, enums, and fields. They can also contain interesting information to compare against in game updates. Metadata can have different value types, I only handle the primitive ones, as there could be more - such as ones that use custom data structures which could also change between engine revisions (e.g Pulse system bindings). These fields get put in comment format above the corresponding definition.

Metadata names that include some value are defined in a separate file as array of values that gets looked up when dumping. This list might not be exhaustive, and it also might change between engine revisions, but probably not that commonly.

Sample output:
```c++
// MGetKV3ClassDefaults
class C_INIT_InitialVelocityNoise : public CParticleFunctionInitializer
{
	// MPropertyFriendlyName = "absolute value"
	// MVectorIsCoordinate
	Vector m_vecAbsVal;
	// MPropertyFriendlyName = "invert abs value"
	// MVectorIsCoordinate
	Vector m_vecAbsValInv;
	// MPropertyFriendlyName = "spatial coordinate offset"
	// MVectorIsCoordinate
	CPerParticleVecInput m_vecOffsetLoc;
	// MPropertyFriendlyName = "time coordinate offset"
	CPerParticleFloatInput m_flOffset;
	// MPropertyFriendlyName = "output minimum"
	CPerParticleVecInput m_vecOutputMin;
	// MPropertyFriendlyName = "output maximum"
	CPerParticleVecInput m_vecOutputMax;
	// MPropertyFriendlyName = "time noise coordinate scale"
	CPerParticleFloatInput m_flNoiseScale;
	// MPropertyFriendlyName = "spatial noise coordinate scale"
	CPerParticleFloatInput m_flNoiseScaleLoc;
	// MPropertyFriendlyName = "input local space velocity (optional)"
	// MParticleInputOptional
	CParticleTransformInput m_TransformInput;
	// MPropertyFriendlyName = "ignore delta time"
	bool m_bIgnoreDt;
};
```

Note 1: I used compile time string hash (FNV1a) for efficient comparison when looking up metadata entries.
Note 2: Some more printable fields could be added (e.g for MNetworkVarNames that uses a compound value with a name and value) I think this could differ a bit between engines, so I didn't touch it yet, but we could still do a commit for that.