### PR TITLE
enrich schemas.json with nullability, handle kinds, ABI layout, and f…

### DIFF
--- a/src/main/dumpers/schemas/json_exporter.cpp
+++ b/src/main/dumpers/schemas/json_exporter.cpp
@@ -30,6 +30,20 @@ using json = nlohmann::json;
 namespace Dumpers::Schemas::JsonExporter
 {
 
+static bool IsFlagsEnum(const std::vector<IntermediateSchemaEnumMember>& members)
+{
+	bool hasNonZero = false;
+	for (const auto& m : members)
+	{
+		if (m.value <= 0)
+			continue;
+		hasNonZero = true;
+		if ((m.value & (m.value - 1)) != 0)
+			return false;
+	}
+	return hasNonZero;
+}
+
 json SerializeMetadataArray(const std::vector<IntermediateMetadata>& metadataVector)
 {
 	json arr = json::array();

--- a/src/main/dumpers/schemas/json_exporter.cpp
+++ b/src/main/dumpers/schemas/json_exporter.cpp
@@ -62,6 +62,7 @@ json SerializeType(CSchemaType* type)
 			break;
 		case SCHEMA_TYPE_POINTER:
 			j["category"] = "ptr";
+			j["nullable"] = true;
 			j["inner"] = SerializeType(static_cast<CSchemaType_Ptr*>(type)->m_pObjectType);
 			break;
 		case SCHEMA_TYPE_FIXED_ARRAY:
@@ -78,18 +79,34 @@ json SerializeType(CSchemaType* type)
 
 			// Extract outer name from m_sTypeName before '<'
 			std::string typeName = type->m_sTypeName.String();
+			std::string outerName;
 			auto pos = typeName.find('<');
 			if (pos != std::string::npos)
 			{
-				auto name = typeName.substr(0, pos);
-				// Trim trailing whitespace
-				while (!name.empty() && name.back() == ' ')
-					name.pop_back();
-				j["name"] = name;
+				outerName = typeName.substr(0, pos);
+				while (!outerName.empty() && outerName.back() == ' ')
+					outerName.pop_back();
 			}
 			else
 			{
-				j["name"] = typeName;
+				outerName = typeName;
+			}
+			j["name"] = outerName;
+
+			if (outerName == "CHandle")
+			{
+				j["handle_kind"] = "entity";
+				j["nullable"] = true;
+			}
+			else if (outerName == "CWeakHandle")
+			{
+				j["handle_kind"] = "weak";
+				j["nullable"] = true;
+			}
+			else if (outerName == "CStrongHandle")
+			{
+				j["handle_kind"] = "strong";
+				j["nullable"] = true;
 			}
 
 			if (type->m_eAtomicCategory == SCHEMA_ATOMIC_T ||
@@ -154,6 +171,10 @@ void DumpClasses(const std::vector<IntermediateSchemaClass>& classes, json& clas
 		classObj["name"] = intermediateClass.name;
 		classObj["module"] = intermediateClass.module;
 		classObj["size"] = intermediateClass.size;
+		if (intermediateClass.alignment != 0)
+			classObj["alignment"] = intermediateClass.alignment;
+		if (intermediateClass.isAbstract)
+			classObj["abstract"] = true;
 
 		auto classMetadataArr = SerializeMetadataArray(intermediateClass.metadata);
 		if (classMetadataArr.size())
@@ -165,6 +186,7 @@ void DumpClasses(const std::vector<IntermediateSchemaClass>& classes, json& clas
 			json parentObj;
 			parentObj["name"] = parent.name;
 			parentObj["module"] = parent.module;
+			parentObj["offset"] = parent.offset;
 			parents.push_back(std::move(parentObj));
 		}
 
@@ -202,6 +224,16 @@ void DumpEnums(const std::vector<IntermediateSchemaEnum>& enums, json& enumsArra
 		enumObj["name"] = intermediateEnum.name;
 		enumObj["module"] = intermediateEnum.module;
 		enumObj["alignment"] = intermediateEnum.stringAlignment;
+		if (intermediateEnum.stringAlignment.has_value())
+		{
+			const auto& align = *intermediateEnum.stringAlignment;
+			if (align == "uint8_t")       enumObj["storage_size"] = 1;
+			else if (align == "uint16_t") enumObj["storage_size"] = 2;
+			else if (align == "uint32_t") enumObj["storage_size"] = 4;
+			else if (align == "uint64_t") enumObj["storage_size"] = 8;
+		}
+		if (IsFlagsEnum(intermediateEnum.members))
+			enumObj["flags"] = true;
 
 		auto enumMetadataArr = SerializeMetadataArray(intermediateEnum.metadata);
 		if (enumMetadataArr.size())
@@ -254,7 +286,7 @@ void Dump(const std::vector<IntermediateSchemaEnum>& enums, const std::vector<In
 	root["enums"] = enumsArray;
 
 	std::ofstream output(Globals::outputPath / "schemas.json");
-	output << root.dump(-1);
+	output << root.dump(2) << "\n";
 	output.close();
 
 	spdlog::info("Wrote schemas.json ({} classes, {} enums)", classesArray.size(), enumsArray.size());

--- a/src/main/dumpers/schemas/schemas.cpp
+++ b/src/main/dumpers/schemas/schemas.cpp
@@ -43,7 +43,9 @@ void DumpClasses(CSchemaSystemTypeScope* typeScope, std::vector<IntermediateSche
 		IntermediateSchemaClass schemaClass{
 			.name = std::string(classInfo->m_pszName),
 			.module = std::string(classInfo->m_pszProjectName),
-			.size = classInfo->m_nSize
+			.size = classInfo->m_nSize,
+			.alignment = classInfo->m_nAlignment,
+			.isAbstract = (classInfo->m_nFlags1 & SCHEMA_CF1_IS_ABSTRACT) != 0,
 		};
 
 		spdlog::trace("Dumping class: '{}'", classInfo->m_pszName);
@@ -68,7 +70,7 @@ void DumpClasses(CSchemaSystemTypeScope* typeScope, std::vector<IntermediateSche
 				if (!baseClass)
 					continue;
 
-				schemaClass.parents.emplace_back(std::string(baseClass->m_pszName), std::string(baseClass->m_pszProjectName));
+				schemaClass.parents.emplace_back(std::string(baseClass->m_pszName), std::string(baseClass->m_pszProjectName), (int32_t)classInfo->m_pBaseClasses[baseIndex].m_nOffset);
 			}
 		}
 

--- a/src/main/dumpers/schemas/schemas.h
+++ b/src/main/dumpers/schemas/schemas.h
@@ -36,6 +36,7 @@ struct IntermediateSchemaClassParent
 {
 	std::string name;
 	std::string module;
+	int32_t offset;
 };
 
 struct IntermediateSchemaClassField
@@ -51,6 +52,8 @@ struct IntermediateSchemaClass
 	std::string name;
 	std::string module;
 	int32_t size;
+	uint8_t alignment;
+	bool isAbstract;
 	std::vector<IntermediateMetadata> metadata;
 	std::vector<IntermediateSchemaClassParent> parents;
 	std::vector<IntermediateSchemaClassField> fields;


### PR DESCRIPTION
Summary

  Adds semantic metadata to schemas.json that downstream consumers (code generators, SDK tooling, analyzers) previously had to re-derive or guess from naming conventions.

  - Nullability: Raw pointers (SCHEMA_TYPE_POINTER) and all handle types (CHandle, CWeakHandle, CStrongHandle) now emit "nullable": true, making it explicit which fields can hold a null/invalid reference without inspecting the type name.
  - Handle kind:  Handle atomics now emit a "handle_kind" field ("entity", "weak", or "strong"). Previously consumers had to string-match the outer type name themselves; this makes the distinction machine-readable and centralizes the logic.
  - Class alignment and abstract flag: Classes now emit "alignment" (when non-zero) and "abstract": true where applicable. Alignment is required for correct struct layout in generated bindings; the abstract flag prevents consumers from instantiating types
  that the engine never instantiates directly.
  - Parent offset: Parent class entries now include "offset", which is necessary for correct multiple-inheritance layout in generated code. Without it, consumers have to assume base classes always start at offset 0, which is incorrect for some CS2 types.
  - Enum storage size: Enums emit a numeric "storage_size" (1, 2, 4, or 8) derived from the alignment string. This lets generated code choose the correct underlying integer type without parsing the string.
  - Flags enum detection: Enums where all members are powers of two are tagged with "flags": true, enabling consumers to generate [Flags]-style enums or bitwise helpers automatically.
  - Pretty-printed output: schemas.json is now written with 2-space indentation and a trailing newline, making diffs human-readable and the file easier to inspect directly.