### PR TITLE
Added more classes with broken defaults

### DIFF
--- a/src/main/dumpers/schemas/metadata_stringifier.cpp
+++ b/src/main/dumpers/schemas/metadata_stringifier.cpp
@@ -57,7 +57,9 @@ std::unordered_set<std::string> g_classWithBrokenDefaults = {
 	"CSkeletonInstance",
 	"CGameSceneNode",
 	"CBodyComponentBaseAnimGraph",
-	"CBodyComponentSkeletonInstance"
+	"CBodyComponentSkeletonInstance",
+	"dynpitchvol_base_t",
+	"dynpitchvol_t"
 };
 
 std::vector<std::regex> g_regexFilters = {


### PR DESCRIPTION
This fixes:

```
// "pitchfrac": -108044310,
// "pitchfrac": 679370730,
...
```